### PR TITLE
Audit fix

### DIFF
--- a/contracts/access/Ownable2Step.sol
+++ b/contracts/access/Ownable2Step.sol
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2022 P2P Validator <info@p2p.org>, OpenZeppelin Contracts (last updated v4.7.0) (access/Ownable.sol)
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import "./Ownable.sol";
+
+/**
+* @notice caller must be pendingOwner
+*/
+error Ownable2Step__CallerNotNewOwner();
+
+/**
+ * @dev Contract module which provides access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership} and {acceptOwnership}.
+ *
+ * This module is used through inheritance. It will make available all functions
+ * from parent (Ownable).
+ */
+abstract contract Ownable2Step is Ownable {
+    address private s_pendingOwner;
+
+    /**
+     * @dev Emits in transferOwnership (start of the transfer)
+     * @param _previousOwner address of the previous owner
+     * @param _newOwner address of the new owner
+     */
+    event OwnershipTransferStarted(address indexed _previousOwner, address indexed _newOwner);
+
+    /**
+     * @dev Returns the address of the pending owner.
+     */
+    function pendingOwner() public view virtual returns (address) {
+        return s_pendingOwner;
+    }
+
+    /**
+     * @dev Starts the ownership transfer of the contract to a new account. Replaces the pending transfer if there is one.
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        s_pendingOwner = newOwner;
+        emit OwnershipTransferStarted(owner(), newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`) and deletes any pending owner.
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual override {
+        delete s_pendingOwner;
+        super._transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev The new owner accepts the ownership transfer.
+     */
+    function acceptOwnership() external {
+        address sender = _msgSender();
+        if (pendingOwner() != sender) {
+            revert Ownable2Step__CallerNotNewOwner();
+        }
+        _transferOwnership(sender);
+    }
+}

--- a/contracts/access/OwnableWithOperator.sol
+++ b/contracts/access/OwnableWithOperator.sol
@@ -3,7 +3,7 @@
 
 pragma solidity 0.8.10;
 
-import "./Ownable.sol";
+import "./Ownable2Step.sol";
 
 /**
 * @notice newOperator is the zero address
@@ -23,7 +23,7 @@ error Access__CallerNeitherOperatorNorOwner(address _caller, address _operator, 
 /**
  * @dev Ownable with an additional role of operator
  */
-abstract contract OwnableWithOperator is Ownable {
+abstract contract OwnableWithOperator is Ownable2Step {
     address private s_operator;
 
     /**

--- a/contracts/feeDistributor/FeeDistributor.sol
+++ b/contracts/feeDistributor/FeeDistributor.sol
@@ -235,7 +235,7 @@ contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeD
     * We strongly recommend against intentional reverts in the receive function
     * because the remaining parties might call `withdraw` again multiple times without waiting
     * for the owner to recover ether for the reverting party.
-    * In fact, as a punishment for the reverting party, before the recoving,
+    * In fact, as a punishment for the reverting party, before the recovering,
     * 1 more regular `withdraw` will happen, rewarding the non-reverting parties again.
     * `recoverEther` function is just an emergency backup plan and does not replace `withdraw`.
     */

--- a/contracts/feeDistributor/FeeDistributor.sol
+++ b/contracts/feeDistributor/FeeDistributor.sol
@@ -290,7 +290,7 @@ contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeD
         // get the contract's balance
         uint256 balance = address(this).balance;
 
-        if (balance > 0) {
+        if (balance > 0) { // only happens if at least 1 party reverted in their receive
             bool success = _sendValue(_to, balance);
 
             if (success) {

--- a/contracts/feeDistributor/FeeDistributor.sol
+++ b/contracts/feeDistributor/FeeDistributor.sol
@@ -3,7 +3,6 @@
 
 pragma solidity 0.8.10;
 
-import "../@openzeppelin/contracts/utils/Address.sol";
 import "../@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "../@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "../@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
@@ -102,14 +101,15 @@ error FeeDistributor__ClientCannotReceiveEther(address _client);
 error FeeDistributor__ReferrerCannotReceiveEther(address _referrer);
 
 /**
+* @notice zero ether balance
+*/
+error FeeDistributor__NothingToWithdraw();
+
+/**
 * @title Contract receiving MEV and priority fees
 * and distributing them to the service and the client.
 */
 contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeDistributor {
-    // Type Declarations
-
-    using Address for address payable;
-
     // State variables
 
     /**
@@ -139,7 +139,7 @@ contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeD
     */
     constructor(
         address _factory,
-        address _service
+        address payable _service
     ) {
         if (!ERC165Checker.supportsInterface(_factory, type(IFeeDistributorFactory).interfaceId)) {
             revert FeeDistributor__NotFactory(_factory);
@@ -149,9 +149,9 @@ contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeD
         }
 
         i_factory = IFeeDistributorFactory(_factory);
-        i_service = payable(_service);
+        i_service = _service;
 
-        (bool serviceCanReceiveEther,) = payable(_service).call{value : 0}("");
+        bool serviceCanReceiveEther = _sendValue(_service, 0);
         if (!serviceCanReceiveEther) {
             revert FeeDistributor__ServiceCannotReceiveEther(_service);
         }
@@ -213,12 +213,12 @@ contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeD
             _referrerConfig.basisPoints
         );
 
-        (bool clientCanReceiveEther,) = payable(_clientConfig.recipient).call{value : 0}("");
+        bool clientCanReceiveEther = _sendValue(_clientConfig.recipient, 0);
         if (!clientCanReceiveEther) {
             revert FeeDistributor__ClientCannotReceiveEther(_clientConfig.recipient);
         }
         if (_referrerConfig.recipient != address(0)) {// if there is a referrer
-            (bool referrerCanReceiveEther,) = payable(_referrerConfig.recipient).call{value : 0}("");
+            bool referrerCanReceiveEther = _sendValue(_referrerConfig.recipient, 0);
             if (!referrerCanReceiveEther) {
                 revert FeeDistributor__ReferrerCannotReceiveEther(_referrerConfig.recipient);
             }
@@ -227,6 +227,17 @@ contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeD
 
     /**
     * @notice Withdraw the whole balance of the contract according to the pre-defined basis points.
+    * @dev In case someone (either service, or client, or referrer) fails to accept ether,
+    * the owner will be able to recover some of their share.
+    * This scenario is very unlikely. It can only happen if that someone is a contract
+    * whose receive function changed its behavior since FeeDistributor's initialization.
+    * It can never happen unless the receiving party themselves wants it to happen.
+    * We strongly recommend against intentional reverts in the receive function
+    * because the remaining parties might call `withdraw` again multiple times without waiting
+    * for the owner to recover ether for the reverting party.
+    * In fact, as a punishment for the reverting party, before the recoving,
+    * 1 more regular `withdraw` will happen, rewarding the non-reverting parties again.
+    * `recoverEther` function is just an emergency backup plan and does not replace `withdraw`.
     */
     function withdraw() external nonReentrant {
         if (s_clientConfig.recipient == address(0)) {
@@ -236,26 +247,58 @@ contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeD
         // get the contract's balance
         uint256 balance = address(this).balance;
 
+        if (balance == 0) {
+            // revert if there is no ether to withdraw
+            revert FeeDistributor__NothingToWithdraw();
+        }
+
         // how much should client get
         uint256 clientAmount = (balance * s_clientConfig.basisPoints) / 10000;
 
-        // how much should referrer get
-        // if s_referrerConfig is not set, s_referrerConfig.basisPoints and referrerAmount will be 0
-        uint256 referrerAmount = (balance * s_referrerConfig.basisPoints) / 10000;
-
         // how much should service get
-        uint256 serviceAmount = balance - clientAmount - referrerAmount;
+        uint256 serviceAmount = balance - clientAmount;
 
-        // send ETH to service
-        i_service.sendValue(serviceAmount);
+        // how much should referrer get
+        uint256 referrerAmount;
 
-        // send ETH to client
-        s_clientConfig.recipient.sendValue(clientAmount);
+        if (s_referrerConfig.recipient != address(0)) {
+            // if there is a referrer
 
-        // send ETH to referrer
-        s_referrerConfig.recipient.sendValue(referrerAmount);
+            referrerAmount = (balance * s_referrerConfig.basisPoints) / 10000;
+            serviceAmount -= referrerAmount;
+
+            // Send ETH to referrer. Ignore the possible yet unlikely revert in the receive function.
+            _sendValue(s_referrerConfig.recipient, referrerAmount);
+        }
+
+        // Send ETH to service. Ignore the possible yet unlikely revert in the receive function.
+        _sendValue(i_service, serviceAmount);
+
+        // Send ETH to client. Ignore the possible yet unlikely revert in the receive function.
+        _sendValue(s_clientConfig.recipient, clientAmount);
 
         emit Withdrawn(serviceAmount, clientAmount, referrerAmount);
+    }
+
+    /**
+    * @notice Recover ether in a rare case when either service, or client, or referrer
+    * refuse to accept ether.
+    */
+    function recoverEther(address payable _to) external onlyOwner {
+        this.withdraw();
+
+        // get the contract's balance
+        uint256 balance = address(this).balance;
+
+        if (balance > 0) {
+            bool success = _sendValue(_to, balance);
+
+            if (success) {
+                emit EtherRecovered(_to, balance);
+            } else {
+                emit EtherRecoveryFailed(_to, balance);
+            }
+        }
     }
 
     /**
@@ -298,5 +341,14 @@ contract FeeDistributor is OwnableTokenRecoverer, ReentrancyGuard, ERC165, IFeeD
      */
     function owner() public view override returns (address) {
         return i_factory.owner();
+    }
+
+    function _sendValue(address payable _recipient, uint256 _amount) internal returns (bool) {
+        (bool success, ) = _recipient.call{
+            value: _amount,
+            gas: gasleft() / 4 // to prevent DOS, should be enough in normal cases
+        }("");
+
+        return success;
     }
 }

--- a/contracts/feeDistributor/IFeeDistributor.sol
+++ b/contracts/feeDistributor/IFeeDistributor.sol
@@ -49,6 +49,20 @@ interface IFeeDistributor is IERC165 {
         uint96 _referrerBasisPoints
     );
 
+    /**
+    * @notice Emits if case there was some ether left after `withdraw` and it has been sent successfully.
+    * @param _to destination address for ether.
+    * @param _amount how much wei the destination address received.
+    */
+    event EtherRecovered(address indexed _to, uint256 _amount);
+
+    /**
+    * @notice Emits if case there was some ether left after `withdraw` and it has failed to recover.
+    * @param _to destination address for ether.
+    * @param _amount how much wei the destination address should have received, but didn't.
+    */
+    event EtherRecoveryFailed(address indexed _to, uint256 _amount);
+
     // Functions
 
     /**

--- a/contracts/mocks/MockAlteringReceive.sol
+++ b/contracts/mocks/MockAlteringReceive.sol
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2022 P2P Validator <info@p2p.org>
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+/**
+* @title This is a mock for testing only.
+* @dev DO NOT deploy in production!
+*/
+contract MockAlteringReceive {
+    bool private s_shouldRevertOnReceive;
+
+    receive() external payable {
+        if (s_shouldRevertOnReceive) {
+            for(;;) {
+                // infinite loop to consume all the gas
+            }
+        }
+    }
+
+    function startRevertingOnReceive() external {
+        s_shouldRevertOnReceive = true;
+    }
+}

--- a/test/factory-test.ts
+++ b/test/factory-test.ts
@@ -57,6 +57,7 @@ describe("FeeDistributorFactory", function () {
         )
 
         await deployerFactory.transferOwnership(owner)
+        await factorySignedByOwner.acceptOwnership()
 
         await expect(factorySignedByOwner.setReferenceInstance(nobody)).to.be.revertedWith(
             `FeeDistributorFactory__NotFeeDistributor`
@@ -85,6 +86,7 @@ describe("FeeDistributorFactory", function () {
         )
 
         await deployerFactory.transferOwnership(owner)
+        await factorySignedByOwner.acceptOwnership()
 
         await expect(factorySignedByOwner.setReferenceInstance(nobody)).to.be.revertedWith(
             `FeeDistributorFactory__NotFeeDistributor`
@@ -187,6 +189,7 @@ describe("FeeDistributorFactory", function () {
         )
 
         await deployerFactory.transferOwnership(owner)
+        await factorySignedByOwner.acceptOwnership()
 
         await factorySignedByOwner.dismissOperator()
         const operatorAfterDismissing = await deployerFactory.operator()
@@ -271,6 +274,7 @@ describe("FeeDistributorFactory", function () {
             )
 
         await feeDistributorFactory.transferOwnership(owner)
+        await factorySignedByOwner.acceptOwnership()
 
         await factorySignedByOwner.transferERC20(erc20.address, nobody, erc20Amount)
         const recipientErc20Balance = await erc20.balanceOf(nobody)

--- a/test/fee-distributor-test.ts
+++ b/test/fee-distributor-test.ts
@@ -26,6 +26,7 @@ describe("FeeDistributor", function () {
     let nobodyFactory: FeeDistributor__factory
 
     let feeDistributorFactory: FeeDistributorFactory
+    let ownerFactoryFactory: FeeDistributorFactory__factory
 
     let deployer: string
     let owner: string
@@ -55,6 +56,8 @@ describe("FeeDistributor", function () {
         // deploy factory contract
         const factoryFactory = new FeeDistributorFactory__factory(deployerSigner)
         feeDistributorFactory = await factoryFactory.deploy({gasLimit: 3000000})
+
+        ownerFactoryFactory = new FeeDistributorFactory__factory(ownerSigner)
     })
 
     it("should not be created with incorrect factory", async function () {
@@ -265,6 +268,8 @@ describe("FeeDistributor", function () {
             )
 
         await feeDistributorFactory.transferOwnership(owner)
+        const factorySignedByOwner = ownerFactoryFactory.attach(feeDistributorFactory.address)
+        await factorySignedByOwner.acceptOwnership()
 
         await feeDistributorSignedByOwner.transferERC20(erc20.address, serviceAddress, erc20Amount)
         const recipientErc20Balance = await erc20.balanceOf(serviceAddress)

--- a/test/foundry/HappyPathWithFuzzing.t.sol
+++ b/test/foundry/HappyPathWithFuzzing.t.sol
@@ -201,7 +201,7 @@ contract HappyPathWithFuzzingTest is Test {
         }
 
         // deploy reference instance of FeeDistributor
-        referenceInstance = new FeeDistributor(address(factory), service);
+        referenceInstance = new FeeDistributor(address(factory), payable(service));
 
         if (service == address(0) || !serviceCanReceiveEther) {
             shouldQuit = true;

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -3,8 +3,8 @@ import {ethers, getNamedAccounts} from "hardhat"
 import {
     FeeDistributor__factory,
     FeeDistributorFactory__factory,
-    FeeDistributorFactory
-} from '../typechain-types'
+    FeeDistributorFactory, MockAlteringReceive__factory
+} from "../typechain-types"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 
 describe("Integration", function () {
@@ -36,7 +36,7 @@ describe("Integration", function () {
     let nobody : string
     let serviceAddress: string
 
-    before(async () => {
+    beforeEach(async () => {
         const namedAccounts = await getNamedAccounts()
 
         deployer = namedAccounts.deployer
@@ -124,5 +124,187 @@ describe("Integration", function () {
 
         // make sure client got its share
         expect(clientAddressBalance).to.equal(totalBlockReward.mul(clientBasisPoints).div(10000))
+    })
+
+    it("recoverEther should simply withdraw in a normal case", async function () {
+        // deoply factory
+        const deployerSignerFactory = new FeeDistributor__factory(deployerSigner)
+
+        // deoply reference instance
+        const feeDistributorReferenceInstance = await deployerSignerFactory.deploy(
+            feeDistributorFactory.address,
+            serviceAddress,
+            { gasLimit: 3000000 }
+        )
+
+        // set reference instance
+        await feeDistributorFactory.setReferenceInstance(feeDistributorReferenceInstance.address)
+
+        // set an operator to create a client instance
+        await feeDistributorFactory.changeOperator(operator)
+
+        const operatorSignerFactory = new FeeDistributorFactory__factory(operatorSigner)
+        const operatorFeeDistributorFactory = operatorSignerFactory.attach(feeDistributorFactory.address)
+
+        const clientAddress = "0x0000000000000000000000000000000000C0FFEE"
+        // create client instance
+        const createFeeDistributorTx = await operatorFeeDistributorFactory.createFeeDistributor(
+            {recipient: clientAddress, basisPoints: clientBasisPoints},
+            {recipient: nobody, basisPoints: referrerBasisPoints},
+        )
+        const createFeeDistributorTxReceipt = await createFeeDistributorTx.wait();
+        const event = createFeeDistributorTxReceipt?.events?.find(event => event.event === 'FeeDistributorCreated');
+        if (!event) {
+            throw Error('No FeeDistributorCreated found')
+        }
+        // retrieve client instance address from event
+        const newlyCreatedFeeDistributorAddress = event.args?._newFeeDistributorAddress
+
+        // set the newly created FeeDistributor contract as coinbase (block rewards recipient)
+        // In the real world this will be done in a validator's settings
+        await ethers.provider.send("hardhat_setCoinbase", [
+            newlyCreatedFeeDistributorAddress,
+        ])
+
+        // simulate producing a new block so that our FeeDistributor contract can get its rewards
+        await ethers.provider.send("evm_mine", [])
+
+        // attach to the FeeDistributor contract with the owner (signer)
+        const feeDistributorSignedByDeployer = deployerSignerFactory.attach(newlyCreatedFeeDistributorAddress)
+
+        const serviceAddressBalanceBefore = await ethers.provider.getBalance(serviceAddress)
+
+        const clientAddressBalanceBefore = await ethers.provider.getBalance(clientAddress)
+
+        // call recoverEther instead of withdraw
+        const recoverEtherTx = await feeDistributorSignedByDeployer.recoverEther(nobody)
+        const recoverEtherTxReceipt = await recoverEtherTx.wait()
+
+        const totalBlockReward = ethers.utils.parseEther('2')
+
+        // get service address balance
+        const serviceAddressBalance = await ethers.provider.getBalance(serviceAddress)
+
+        // make sure P2P (service) got its share
+        expect(serviceAddressBalance.sub(serviceAddressBalanceBefore)).to.equal(totalBlockReward.mul(serviceBasisPoints).div(10000))
+
+        // get client address balance
+        const clientAddressBalance = await ethers.provider.getBalance(clientAddress)
+
+        // make sure client got its share
+        expect(clientAddressBalance.sub(clientAddressBalanceBefore)).to.equal(totalBlockReward.mul(clientBasisPoints).div(10000))
+
+        // no recovery should happen if the normal withdraw completed successfully
+        const EtherRecoveredEvent = recoverEtherTxReceipt?.events?.find(event => event.event === 'EtherRecovered')
+        const EtherRecoveryFailedEvent = recoverEtherTxReceipt?.events?.find(event => event.event === 'EtherRecoveryFailed')
+        expect(!!EtherRecoveredEvent).to.be.false
+        expect(!!EtherRecoveryFailedEvent).to.be.false
+    })
+
+    it("recoverEther should recover ether unclaimed during withdraw", async function () {
+        // deoply factory
+        const deployerSignerFactory = new FeeDistributor__factory(deployerSigner)
+
+        // deoply reference instance
+        const feeDistributorReferenceInstance = await deployerSignerFactory.deploy(
+            feeDistributorFactory.address,
+            serviceAddress,
+            { gasLimit: 3000000 }
+        )
+
+        // set reference instance
+        await feeDistributorFactory.setReferenceInstance(feeDistributorReferenceInstance.address)
+
+        // set an operator to create a client instance
+        await feeDistributorFactory.changeOperator(operator)
+
+        const operatorSignerFactory = new FeeDistributorFactory__factory(operatorSigner)
+        const operatorFeeDistributorFactory = operatorSignerFactory.attach(feeDistributorFactory.address)
+
+        const mockAlteringReceiveFactory = new MockAlteringReceive__factory(deployerSigner)
+        const mockAlteringReceive = await mockAlteringReceiveFactory.deploy()
+        const clientAddress = mockAlteringReceive.address
+
+        // create client instance
+        const createFeeDistributorTx = await operatorFeeDistributorFactory.createFeeDistributor(
+            {recipient: clientAddress, basisPoints: clientBasisPoints},
+            {recipient: nobody, basisPoints: referrerBasisPoints},
+        )
+        const createFeeDistributorTxReceipt = await createFeeDistributorTx.wait()
+        const event = createFeeDistributorTxReceipt?.events?.find(event => event.event === 'FeeDistributorCreated');
+        if (!event) {
+            throw Error('No FeeDistributorCreated found')
+        }
+        // retrieve client instance address from event
+        const newlyCreatedFeeDistributorAddress = event.args?._newFeeDistributorAddress
+
+        // set the newly created FeeDistributor contract as coinbase (block rewards recipient)
+        // In the real world this will be done in a validator's settings
+        await ethers.provider.send("hardhat_setCoinbase", [
+            newlyCreatedFeeDistributorAddress,
+        ])
+
+        // simulate producing a new block so that our FeeDistributor contract can get its rewards
+        await ethers.provider.send("evm_mine", [])
+
+        // stop collecting rewards
+        await ethers.provider.send("hardhat_setCoinbase", [
+            ethers.constants.AddressZero,
+        ])
+
+        // attach to the FeeDistributor contract with the owner (signer)
+        const feeDistributorSignedByDeployer = deployerSignerFactory.attach(newlyCreatedFeeDistributorAddress)
+
+        const serviceAddressBalanceBefore = await ethers.provider.getBalance(serviceAddress)
+        const clientAddressBalanceBefore = await ethers.provider.getBalance(clientAddress)
+
+        await mockAlteringReceive.startRevertingOnReceive()
+        const withdrawTx = await feeDistributorSignedByDeployer.withdraw()
+        const withdrawTxReceipt = await withdrawTx.wait()
+
+        const totalBlockReward = ethers.utils.parseEther('2')
+
+        // get service address balance
+        const serviceAddressBalance = await ethers.provider.getBalance(serviceAddress)
+        // get client address balance
+        const clientAddressBalance = await ethers.provider.getBalance(clientAddress)
+
+        // make sure P2P (service) got its share
+        expect(serviceAddressBalance.sub(serviceAddressBalanceBefore)).to.equal(totalBlockReward.mul(serviceBasisPoints).div(10000))
+        // client did not get its share due to the revert
+        expect(clientAddressBalance.sub(clientAddressBalanceBefore)).to.equal(0)
+
+        const serviceAddressBalanceBeforeRecoverEther = await ethers.provider.getBalance(serviceAddress)
+        const clientAddressBalanceBeforeRecoverEther = await ethers.provider.getBalance(clientAddress)
+        const remainingEtherBefore = await ethers.provider.getBalance(newlyCreatedFeeDistributorAddress)
+        const recoverDestinationEtherBefore = await ethers.provider.getBalance(nobody)
+
+        // recoverEther
+        const recoverEtherTx = await feeDistributorSignedByDeployer.recoverEther(nobody)
+        const recoverEtherTxReceipt = await recoverEtherTx.wait()
+        // recoverEther
+
+        const serviceAddressBalanceAfterRecoverEther = await ethers.provider.getBalance(serviceAddress)
+        const clientAddressBalanceAfterRecoverEther = await ethers.provider.getBalance(clientAddress)
+
+        // make sure P2P (service) got its share
+        expect(serviceAddressBalanceAfterRecoverEther.sub(serviceAddressBalanceBeforeRecoverEther))
+            .to.equal(remainingEtherBefore.mul(serviceBasisPoints).div(10000))
+        // client did not get its share due to the revert
+        expect(clientAddressBalanceAfterRecoverEther.sub(clientAddressBalanceBeforeRecoverEther))
+            .to.equal(0)
+
+        // recovery should happen
+        const EtherRecoveredEvent = recoverEtherTxReceipt?.events?.find(event => event.event === 'EtherRecovered')
+        const EtherRecoveryFailedEvent = recoverEtherTxReceipt?.events?.find(event => event.event === 'EtherRecoveryFailed')
+        expect(!!EtherRecoveredEvent).to.be.true
+        expect(!!EtherRecoveryFailedEvent).to.be.false
+
+        const recoverDestinationEtherAfter = await ethers.provider.getBalance(nobody)
+        expect(recoverDestinationEtherAfter.sub(recoverDestinationEtherBefore))
+            .to.equal(remainingEtherBefore.mul(10000 - serviceBasisPoints).div(10000))
+
+        const remainingEtherAfter = await ethers.provider.getBalance(newlyCreatedFeeDistributorAddress)
+        expect(remainingEtherAfter).to.equal(0)
     })
 })


### PR DESCRIPTION
#### 1. Possibility of the ownership transfer to an uncontrolled address
##### Description
The [transfer of the ownership](https://github.com/p2p-org/eth-staking-fee-distributor-contracts/blob/4bac8f636d7ba14244612bcfb9e85f338feba6e3/contracts/access/Ownable.sol#L47) can be performed to an arbitrary account whether or not it is controlled by the current authority.
After the transfer to an uncontrolled account, the ownership will be lost.
##### Recommendation
We recommend using a two-step ownership transfer procedure, including the confirmation (accept) of the ownership transfer.

#### 2. Ether stuck in the `FeeDistributor`
##### Description
If one of the fee receivers can't accept ether (i.e the transaction will revert or consume too much gas), no ether can be [withdrawn](https://github.com/p2p-org/eth-staking-fee-distributor-contracts/blob/4bac8f636d7ba14244612bcfb9e85f338feba6e3/contracts/feeDistributor/FeeDistributor.sol#L231).
Although a new instance can be redeployed, some ether may stuck in the recent instance.
##### Recommendation
We recommend implementing the functionality to migrate from a stuck `FeeDistributor` instance to a new one.

#### 4. No null checks for recipient in s_referrerConfig
##### Description
If `recipient` in `s_referrerConfig` is a null address, then there is no need to calculate `referrerAmount`, because `referrerAmount` will always be 0.
Also, `referrerAmount` will be redundant for `serviceAmount`. Additionaly, we can bypass calling the `sendValue` with zero value and null address.

https://github.com/p2p-org/eth-staking-fee-distributor-contracts/blob/4bac8f636d7ba14244612bcfb9e85f338feba6e3/contracts/feeDistributor/FeeDistributor.sol#L256  
https://github.com/p2p-org/eth-staking-fee-distributor-contracts/blob/4bac8f636d7ba14244612bcfb9e85f338feba6e3/contracts/feeDistributor/FeeDistributor.sol#L244  
https://github.com/p2p-org/eth-staking-fee-distributor-contracts/blob/4bac8f636d7ba14244612bcfb9e85f338feba6e3/contracts/feeDistributor/FeeDistributor.sol#L247  
##### Recommendation
We recommend adding a null check for `recipient` in `s_referrerConfig` in the `withdraw` function and update logic for gas saving.