### PR TITLE
Audit 3 fix

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -398,3 +398,4 @@ bfa
 feba
 baf
 dac
+cooldown

--- a/contracts/access/Ownable2Step.sol
+++ b/contracts/access/Ownable2Step.sol
@@ -11,6 +11,11 @@ import "./Ownable.sol";
 error Ownable2Step__CallerNotNewOwner();
 
 /**
+* @notice new owner address should be different from the current owner
+*/
+error Ownable2Step__NewOwnerShouldNotBeCurrentOwner();
+
+/**
  * @dev Contract module which provides access control mechanism, where
  * there is an account (an owner) that can be granted exclusive access to
  * specific functions.
@@ -43,8 +48,13 @@ abstract contract Ownable2Step is Ownable {
      * Can only be called by the current owner.
      */
     function transferOwnership(address newOwner) public virtual override onlyOwner {
+        address currentOwner = owner();
+        if (newOwner == currentOwner) {
+            revert Ownable2Step__NewOwnerShouldNotBeCurrentOwner();
+        }
+
         s_pendingOwner = newOwner;
-        emit OwnershipTransferStarted(owner(), newOwner);
+        emit OwnershipTransferStarted(currentOwner, newOwner);
     }
 
     /**

--- a/contracts/access/OwnableWithOperator.sol
+++ b/contracts/access/OwnableWithOperator.sol
@@ -60,7 +60,7 @@ abstract contract OwnableWithOperator is Ownable2Step, IOwnableWithOperator {
         address currentOwner = owner();
         address currentOperator = s_operator;
 
-        if (currentOperator != _address && currentOwner != _address) {
+        if (_address == address(0) || (currentOperator != _address && currentOwner != _address)) {
             revert Access__AddressNeitherOperatorNorOwner(_address, currentOperator, currentOwner);
         }
     }

--- a/contracts/assetRecovering/OwnableTokenRecoverer.sol
+++ b/contracts/assetRecovering/OwnableTokenRecoverer.sol
@@ -35,15 +35,13 @@ abstract contract OwnableTokenRecoverer is TokenRecoverer, OwnableBase {
      * @param _token address of the ERC721 token
      * @param _recipient address to transfer the token to
      * @param _tokenId id of the individual token
-     * @param _data data to transfer along
      */
     function transferERC721(
         address _token,
         address _recipient,
-        uint256 _tokenId,
-        bytes calldata _data
+        uint256 _tokenId
     ) external onlyOwner {
-        _transferERC721(_token, _recipient, _tokenId, _data);
+        _transferERC721(_token, _recipient, _tokenId);
     }
 
     /**

--- a/contracts/assetRecovering/TokenRecoverer.sol
+++ b/contracts/assetRecovering/TokenRecoverer.sol
@@ -22,7 +22,7 @@ abstract contract TokenRecoverer {
     using SafeERC20 for IERC20;
 
     event ERC20Transferred(address indexed _token, address indexed _recipient, uint256 _amount);
-    event ERC721Transferred(address indexed _token, address indexed _recipient, uint256 _tokenId, bytes _data);
+    event ERC721Transferred(address indexed _token, address indexed _recipient, uint256 _tokenId);
     event ERC1155Transferred(address indexed _token, address indexed _recipient, uint256 _tokenId, uint256 _amount, bytes _data);
 
     /**
@@ -61,16 +61,14 @@ abstract contract TokenRecoverer {
      * @param _token address of the ERC721 token
      * @param _recipient address to transfer the token to
      * @param _tokenId id of the individual token
-     * @param _data data to transfer along
      */
     function _transferERC721(
         address _token,
         address _recipient,
-        uint256 _tokenId,
-        bytes calldata _data
+        uint256 _tokenId
     ) internal virtual burnDisallowed(_recipient) {
-        IERC721(_token).safeTransferFrom(address(this), _recipient, _tokenId, _data);
-        emit ERC721Transferred(_token, _recipient, _tokenId, _data);
+        IERC721(_token).transferFrom(address(this), _recipient, _tokenId);
+        emit ERC721Transferred(_token, _recipient, _tokenId);
     }
 
     /**

--- a/contracts/constants/P2pConstants.sol
+++ b/contracts/constants/P2pConstants.sol
@@ -11,6 +11,9 @@ uint256 constant VALIDATORS_MAX_AMOUNT = 400;
 /// @dev Collateral size of 1 validator
 uint256 constant COLLATERAL = 32 ether;
 
+/// @dev Minimal 1 time deposit
+uint256 constant MIN_DEPOSIT = 1 ether;
+
 /// @dev Lockup time to allow P2P to make ETH2 deposits
 /// @dev If there is leftover ETH after this time, it can be refunded
 uint40 constant TIMEOUT = 1 days;

--- a/contracts/constants/P2pConstants.sol
+++ b/contracts/constants/P2pConstants.sol
@@ -14,3 +14,6 @@ uint256 constant COLLATERAL = 32 ether;
 /// @dev Lockup time to allow P2P to make ETH2 deposits
 /// @dev If there is leftover ETH after this time, it can be refunded
 uint40 constant TIMEOUT = 1 days;
+
+/// @dev Cooldown period for the client to restore their ETH receiving ability to receive their collaterals
+uint256 constant COOLDOWN = 30 days;

--- a/contracts/feeDistributor/BaseFeeDistributor.sol
+++ b/contracts/feeDistributor/BaseFeeDistributor.sol
@@ -85,7 +85,7 @@ abstract contract BaseFeeDistributor is Erc4337Account, OwnableTokenRecoverer, O
         if (s_clientConfig.recipient != address(0)) {
             revert FeeDistributor__ClientAlreadySet(s_clientConfig.recipient);
         }
-        if (_clientConfig.basisPoints > 10000) {
+        if (_clientConfig.basisPoints >= 10000) {
             revert FeeDistributor__InvalidClientBasisPoints(_clientConfig.basisPoints);
         }
 

--- a/contracts/feeDistributor/BaseFeeDistributor.sol
+++ b/contracts/feeDistributor/BaseFeeDistributor.sol
@@ -75,7 +75,7 @@ abstract contract BaseFeeDistributor is Erc4337Account, OwnableTokenRecoverer, O
     function initialize(
         FeeRecipient calldata _clientConfig,
         FeeRecipient calldata _referrerConfig
-    ) external onlyFactory {
+    ) public virtual onlyFactory {
         if (_clientConfig.recipient == address(0)) {
             revert FeeDistributor__ZeroAddressClient();
         }

--- a/contracts/feeDistributor/BaseFeeDistributor.sol
+++ b/contracts/feeDistributor/BaseFeeDistributor.sol
@@ -96,6 +96,9 @@ abstract contract BaseFeeDistributor is Erc4337Account, OwnableTokenRecoverer, O
             if (_referrerConfig.recipient == _clientConfig.recipient) {
                 revert FeeDistributor__ReferrerAddressEqualsClient(_referrerConfig.recipient);
             }
+            if (_referrerConfig.basisPoints == 0) {
+                revert FeeDistributor__ZeroReferrerBasisPointsForNonZeroReferrer();
+            }
             if (_clientConfig.basisPoints + _referrerConfig.basisPoints > 10000) {
                 revert FeeDistributor__ClientPlusReferralBasisPointsExceed10000(
                     _clientConfig.basisPoints,

--- a/contracts/feeDistributor/ContractWcFeeDistributor.sol
+++ b/contracts/feeDistributor/ContractWcFeeDistributor.sol
@@ -47,7 +47,7 @@ contract ContractWcFeeDistributor is BaseFeeDistributor {
     /// ETH receiving functionality. After this cooldown period expires, if the client still doesn't accept ETH,
     /// their collaterals will be split as regular rewards.
     /// @param _cooldownUntil block timestamp until which it's impossible to bypass client's revert on ETH receive
-    event ContractWcFeeDistributor__ClientRevertOnCollatralReceive(
+    event ContractWcFeeDistributor__ClientRevertOnCollateralReceive(
         uint80 _cooldownUntil
     );
 
@@ -159,7 +159,7 @@ contract ContractWcFeeDistributor is BaseFeeDistributor {
                     s_validatorData.cooldownUntil = uint80(block.timestamp + COOLDOWN);
                 }
 
-                emit ContractWcFeeDistributor__ClientRevertOnCollatralReceive(s_validatorData.cooldownUntil);
+                emit ContractWcFeeDistributor__ClientRevertOnCollateralReceive(s_validatorData.cooldownUntil);
 
                 if (block.timestamp < s_validatorData.cooldownUntil) {
                     return; // prevent further ETH sending

--- a/contracts/feeDistributor/ContractWcFeeDistributor.sol
+++ b/contracts/feeDistributor/ContractWcFeeDistributor.sol
@@ -114,8 +114,7 @@ contract ContractWcFeeDistributor is BaseFeeDistributor {
         if (balance >= COLLATERAL && s_validatorData.collateralReturnedCount < s_validatorData.exitedCount) {
             // if exited and some validators withdrawn
 
-            // integer division
-            uint32 collateralsCountToReturn = uint32(balance / COLLATERAL);
+            uint32 collateralsCountToReturn = s_validatorData.exitedCount - s_validatorData.collateralReturnedCount;
 
             s_validatorData.collateralReturnedCount += collateralsCountToReturn;
 

--- a/contracts/feeDistributor/ContractWcFeeDistributor.sol
+++ b/contracts/feeDistributor/ContractWcFeeDistributor.sol
@@ -42,7 +42,7 @@ contract ContractWcFeeDistributor is BaseFeeDistributor {
         uint112 _newCollateralReturnedValue
     );
 
-    /// @notice Emits when the client reverted on collatral receive.
+    /// @notice Emits when the client reverted on collateral receive.
     /// @dev Highly unlikely scenario. Turns on a 30 days cooldown period for the client to turn back on their
     /// ETH receiving functionality. After this cooldown period expires, if the client still doesn't accept ETH,
     /// their collaterals will be split as regular rewards.

--- a/contracts/feeDistributor/ContractWcFeeDistributor.sol
+++ b/contracts/feeDistributor/ContractWcFeeDistributor.sol
@@ -226,7 +226,7 @@ contract ContractWcFeeDistributor is BaseFeeDistributor {
             if (success) {
                 emit FeeDistributor__EtherRecovered(_to, balance);
             } else {
-                emit FeeDistributor__EtherRecoveryFailed(_to, balance);
+                revert FeeDistributor__EtherRecoveryFailed(_to, balance);
             }
         }
     }

--- a/contracts/feeDistributor/ContractWcFeeDistributor.sol
+++ b/contracts/feeDistributor/ContractWcFeeDistributor.sol
@@ -215,6 +215,10 @@ contract ContractWcFeeDistributor is BaseFeeDistributor {
     /// refuse to accept ether.
     /// @param _to receiver address
     function recoverEther(address payable _to) external onlyOwner {
+        if (_to == address(0)) {
+            revert FeeDistributor__ZeroAddressEthReceiver();
+        }
+
         this.withdraw();
 
         // get the contract's balance

--- a/contracts/feeDistributor/ElOnlyFeeDistributor.sol
+++ b/contracts/feeDistributor/ElOnlyFeeDistributor.sol
@@ -92,7 +92,7 @@ contract ElOnlyFeeDistributor is BaseFeeDistributor {
             if (success) {
                 emit FeeDistributor__EtherRecovered(_to, balance);
             } else {
-                emit FeeDistributor__EtherRecoveryFailed(_to, balance);
+                revert FeeDistributor__EtherRecoveryFailed(_to, balance);
             }
         }
     }

--- a/contracts/feeDistributor/ElOnlyFeeDistributor.sol
+++ b/contracts/feeDistributor/ElOnlyFeeDistributor.sol
@@ -81,6 +81,10 @@ contract ElOnlyFeeDistributor is BaseFeeDistributor {
     /// refuse to accept ether.
     /// @param _to receiver address
     function recoverEther(address payable _to) external onlyOwner {
+        if (_to == address(0)) {
+            revert FeeDistributor__ZeroAddressEthReceiver();
+        }
+
         this.withdraw();
 
         // get the contract's balance

--- a/contracts/feeDistributor/FeeDistributorErrors.sol
+++ b/contracts/feeDistributor/FeeDistributorErrors.sol
@@ -23,6 +23,9 @@ error FeeDistributor__ZeroAddressClient();
 /// @param _clientBasisPoints passed incorrect client basis points
 error FeeDistributor__InvalidClientBasisPoints(uint96 _clientBasisPoints);
 
+/// @notice Referrer basis points should be > 0 if the referrer exists
+error FeeDistributor__ZeroReferrerBasisPointsForNonZeroReferrer();
+
 /// @notice The sum of (Client basis points + Referral basis points) should be >= 0 and <= 10000
 /// @param _clientBasisPoints passed client basis points
 /// @param _referralBasisPoints passed referral basis points

--- a/contracts/feeDistributor/FeeDistributorErrors.sol
+++ b/contracts/feeDistributor/FeeDistributorErrors.sol
@@ -72,3 +72,11 @@ error FeeDistributor__NothingToWithdraw();
 /// @param _caller address of the caller
 /// @param _client address of the client
 error FeeDistributor__CallerNotClient(address _caller, address _client);
+
+/// @notice Throws in case there was some ether left after `withdraw` and it has failed to recover.
+/// @param _to destination address for ether.
+/// @param _amount how much wei the destination address should have received, but didn't.
+error FeeDistributor__EtherRecoveryFailed(
+    address _to,
+    uint256 _amount
+);

--- a/contracts/feeDistributor/FeeDistributorErrors.sol
+++ b/contracts/feeDistributor/FeeDistributorErrors.sol
@@ -80,3 +80,6 @@ error FeeDistributor__EtherRecoveryFailed(
     address _to,
     uint256 _amount
 );
+
+/// @notice ETH receiver should not be a zero address
+error FeeDistributor__ZeroAddressEthReceiver();

--- a/contracts/feeDistributor/IFeeDistributor.sol
+++ b/contracts/feeDistributor/IFeeDistributor.sol
@@ -45,14 +45,6 @@ interface IFeeDistributor is IERC165 {
         uint256 _amount
     );
 
-    /// @notice Emits if case there was some ether left after `withdraw` and it has failed to recover.
-    /// @param _to destination address for ether.
-    /// @param _amount how much wei the destination address should have received, but didn't.
-    event FeeDistributor__EtherRecoveryFailed(
-        address indexed _to,
-        uint256 _amount
-    );
-
     /// @notice Set client address.
     /// @dev Could not be in the constructor since it is different for different clients.
     /// _referrerConfig can be zero if there is no referrer.

--- a/contracts/feeDistributor/OracleFeeDistributor.sol
+++ b/contracts/feeDistributor/OracleFeeDistributor.sol
@@ -214,7 +214,7 @@ contract OracleFeeDistributor is BaseFeeDistributor {
         uint256 balance = address(this).balance;
 
         if (balance > 0) { // only happens if at least 1 party reverted in their receive
-            bool success = P2pAddressLib._sendValue(_to, balance);
+            bool success = P2pAddressLib._sendValueWithoutGasRestrictions(_to, balance);
 
             if (success) {
                 emit FeeDistributor__EtherRecovered(_to, balance);

--- a/contracts/feeDistributor/OracleFeeDistributor.sol
+++ b/contracts/feeDistributor/OracleFeeDistributor.sol
@@ -124,7 +124,7 @@ contract OracleFeeDistributor is BaseFeeDistributor {
         // Gwei to Wei
         uint256 amount = _amountInGwei * (10 ** 9);
 
-        if (balance + amount < s_clientOnlyClRewards) {
+        if (amount < s_clientOnlyClRewards) {
             // Can happen if the client has called emergencyEtherRecoveryWithoutOracleData before
             // but the actual rewards amount now appeared to be lower than the already split.
             // Should happen rarely.

--- a/contracts/feeDistributor/OracleFeeDistributor.sol
+++ b/contracts/feeDistributor/OracleFeeDistributor.sol
@@ -219,7 +219,7 @@ contract OracleFeeDistributor is BaseFeeDistributor {
             if (success) {
                 emit FeeDistributor__EtherRecovered(_to, balance);
             } else {
-                emit FeeDistributor__EtherRecoveryFailed(_to, balance);
+                revert FeeDistributor__EtherRecoveryFailed(_to, balance);
             }
         }
     }

--- a/contracts/feeDistributor/OracleFeeDistributor.sol
+++ b/contracts/feeDistributor/OracleFeeDistributor.sol
@@ -162,10 +162,9 @@ contract OracleFeeDistributor is BaseFeeDistributor {
             clientAmount = balance - serviceAmount;
         }
 
-        // client gets the rest from CL as not split anymore amount
-        s_clientOnlyClRewards += (totalAmountToSplit - balance);
-
         emit OracleFeeDistributor__ClientOnlyClRewardsUpdated(s_clientOnlyClRewards);
+
+        bool someEthSent;
 
         // how much should referrer get
         uint256 referrerAmount;
@@ -178,14 +177,19 @@ contract OracleFeeDistributor is BaseFeeDistributor {
             serviceAmount -= referrerAmount;
 
             // Send ETH to referrer. Ignore the possible yet unlikely revert in the receive function.
-            P2pAddressLib._sendValue(s_referrerConfig.recipient, referrerAmount);
+            someEthSent = P2pAddressLib._sendValue(s_referrerConfig.recipient, referrerAmount);
         }
 
         // Send ETH to service. Ignore the possible yet unlikely revert in the receive function.
-        P2pAddressLib._sendValue(i_service, serviceAmount);
+        someEthSent = P2pAddressLib._sendValue(i_service, serviceAmount) || someEthSent;
 
         // Send ETH to client. Ignore the possible yet unlikely revert in the receive function.
-        P2pAddressLib._sendValue(s_clientConfig.recipient, clientAmount);
+        someEthSent = P2pAddressLib._sendValue(s_clientConfig.recipient, clientAmount) || someEthSent;
+
+        if (someEthSent) {
+            // client gets the rest from CL as not split anymore amount
+            s_clientOnlyClRewards += (totalAmountToSplit - balance);
+        }
 
         emit FeeDistributor__Withdrawn(
             serviceAmount,
@@ -241,10 +245,9 @@ contract OracleFeeDistributor is BaseFeeDistributor {
         // the total amount being split fits the actual balance of this contract
         uint256 totalAmountToSplit = (halfBalance * 10000) / (10000 - s_clientConfig.basisPoints);
 
-        // client gets the rest from CL as not split anymore amount
-        s_clientOnlyClRewards += (totalAmountToSplit - balance);
-
         emit OracleFeeDistributor__ClientOnlyClRewardsUpdated(s_clientOnlyClRewards);
+
+        bool someEthSent;
 
         // how much should referrer get
         uint256 referrerAmount;
@@ -257,14 +260,19 @@ contract OracleFeeDistributor is BaseFeeDistributor {
             serviceAmount -= referrerAmount;
 
             // Send ETH to referrer. Ignore the possible yet unlikely revert in the receive function.
-            P2pAddressLib._sendValue(s_referrerConfig.recipient, referrerAmount);
+            someEthSent = P2pAddressLib._sendValue(s_referrerConfig.recipient, referrerAmount);
         }
 
         // Send ETH to service. Ignore the possible yet unlikely revert in the receive function.
-        P2pAddressLib._sendValue(i_service, serviceAmount);
+        someEthSent = P2pAddressLib._sendValue(i_service, serviceAmount) || someEthSent;
 
         // Send ETH to client. Ignore the possible yet unlikely revert in the receive function.
-        P2pAddressLib._sendValue(s_clientConfig.recipient, clientAmount);
+        someEthSent = P2pAddressLib._sendValue(s_clientConfig.recipient, clientAmount) || someEthSent;
+
+        if (someEthSent) {
+            // client gets the rest from CL as not split anymore amount
+            s_clientOnlyClRewards += (totalAmountToSplit - balance);
+        }
 
         emit FeeDistributor__Withdrawn(
             serviceAmount,

--- a/contracts/feeDistributor/OracleFeeDistributor.sol
+++ b/contracts/feeDistributor/OracleFeeDistributor.sol
@@ -208,6 +208,10 @@ contract OracleFeeDistributor is BaseFeeDistributor {
         bytes32[] calldata _proof,
         uint256 _amountInGwei
     ) external onlyOwner {
+        if (_to == address(0)) {
+            revert FeeDistributor__ZeroAddressEthReceiver();
+        }
+
         this.withdraw(_proof, _amountInGwei);
 
         // get the contract's balance

--- a/contracts/feeDistributor/OracleFeeDistributor.sol
+++ b/contracts/feeDistributor/OracleFeeDistributor.sol
@@ -23,6 +23,9 @@ error OracleFeeDistributor__WaitForEnoughRewardsToWithdraw();
 /// @notice clientOnlyClRewards can only be set once
 error OracleFeeDistributor__CannotResetClientOnlyClRewards();
 
+/// @notice Client basis points should be higher than 5000
+error OracleFeeDistributor__ClientBasisPointsShouldBeHigherThan5000();
+
 /// @title FeeDistributor accepting EL rewards only but splitting them with consideration of CL rewards
 /// @dev CL rewards are received by the client directly since client's address is ETH2 withdrawal credentials
 contract OracleFeeDistributor is BaseFeeDistributor {
@@ -54,6 +57,18 @@ contract OracleFeeDistributor is BaseFeeDistributor {
         }
 
         i_oracle = IOracle(_oracle);
+    }
+
+    /// @inheritdoc IFeeDistributor
+    function initialize(
+        FeeRecipient calldata _clientConfig,
+        FeeRecipient calldata _referrerConfig
+    ) public override {
+        if (_clientConfig.basisPoints <= 5000) {
+            revert OracleFeeDistributor__ClientBasisPointsShouldBeHigherThan5000();
+        }
+
+        super.initialize(_clientConfig, _referrerConfig);
     }
 
     /// @notice Set clientOnlyClRewards to a new value

--- a/contracts/feeDistributorFactory/FeeDistributorFactory.sol
+++ b/contracts/feeDistributorFactory/FeeDistributorFactory.sol
@@ -53,7 +53,7 @@ contract FeeDistributorFactory is OwnableAssetRecoverer, OwnableWithOperator, ER
     /// @dev Set values known at the initial deploy time.
     /// @param _defaultClientBasisPoints Default Client Basis Points
     constructor(uint96 _defaultClientBasisPoints) {
-        if (_defaultClientBasisPoints > 10000) {
+        if (_defaultClientBasisPoints >= 10000) {
             revert FeeDistributorFactory__InvalidDefaultClientBasisPoints(_defaultClientBasisPoints);
         }
 
@@ -76,7 +76,7 @@ contract FeeDistributorFactory is OwnableAssetRecoverer, OwnableWithOperator, ER
     /// @notice Set a new Default Client Basis Points
     /// @param _defaultClientBasisPoints Default Client Basis Points
     function setDefaultClientBasisPoints(uint96 _defaultClientBasisPoints) external onlyOwner {
-        if (_defaultClientBasisPoints > 10000) {
+        if (_defaultClientBasisPoints >= 10000) {
             revert FeeDistributorFactory__InvalidDefaultClientBasisPoints(_defaultClientBasisPoints);
         }
 

--- a/contracts/feeDistributorFactory/FeeDistributorFactory.sol
+++ b/contracts/feeDistributorFactory/FeeDistributorFactory.sol
@@ -29,6 +29,10 @@ error FeeDistributorFactory__ReferenceFeeDistributorNotSet();
 /// @param _caller calling address
 error FeeDistributorFactory__CallerNotAuthorized(address _caller);
 
+/// @notice Default client basis points should be >= 0 and <= 10000
+/// @param _defaultClientBasisPoints passed incorrect default client basis points
+error FeeDistributorFactory__InvalidDefaultClientBasisPoints(uint96 _defaultClientBasisPoints);
+
 /// @title Factory for cloning (EIP-1167) FeeDistributor instances pre client
 contract FeeDistributorFactory is OwnableAssetRecoverer, OwnableWithOperator, ERC165, IFeeDistributorFactory {
 
@@ -49,6 +53,10 @@ contract FeeDistributorFactory is OwnableAssetRecoverer, OwnableWithOperator, ER
     /// @dev Set values known at the initial deploy time.
     /// @param _defaultClientBasisPoints Default Client Basis Points
     constructor(uint96 _defaultClientBasisPoints) {
+        if (_defaultClientBasisPoints > 10000) {
+            revert FeeDistributorFactory__InvalidDefaultClientBasisPoints(_defaultClientBasisPoints);
+        }
+
         s_defaultClientBasisPoints = _defaultClientBasisPoints;
 
         emit FeeDistributorFactory__DefaultClientBasisPointsSet(_defaultClientBasisPoints);
@@ -68,6 +76,10 @@ contract FeeDistributorFactory is OwnableAssetRecoverer, OwnableWithOperator, ER
     /// @notice Set a new Default Client Basis Points
     /// @param _defaultClientBasisPoints Default Client Basis Points
     function setDefaultClientBasisPoints(uint96 _defaultClientBasisPoints) external onlyOwner {
+        if (_defaultClientBasisPoints > 10000) {
+            revert FeeDistributorFactory__InvalidDefaultClientBasisPoints(_defaultClientBasisPoints);
+        }
+
         s_defaultClientBasisPoints = _defaultClientBasisPoints;
 
         emit FeeDistributorFactory__DefaultClientBasisPointsSet(_defaultClientBasisPoints);

--- a/contracts/feeDistributorFactory/FeeDistributorFactory.sol
+++ b/contracts/feeDistributorFactory/FeeDistributorFactory.sol
@@ -125,9 +125,13 @@ contract FeeDistributorFactory is OwnableAssetRecoverer, OwnableWithOperator, ER
     /// @inheritdoc IFeeDistributorFactory
     function predictFeeDistributorAddress(
         address _referenceFeeDistributor,
-        FeeRecipient calldata _clientConfig,
+        FeeRecipient memory _clientConfig,
         FeeRecipient calldata _referrerConfig
     ) public view returns (address) {
+        if (_clientConfig.basisPoints == 0) {
+            _clientConfig.basisPoints = s_defaultClientBasisPoints;
+        }
+
         return Clones.predictDeterministicAddress(
             _referenceFeeDistributor,
             _getSalt(_clientConfig, _referrerConfig)

--- a/contracts/lib/P2pAddressLib.sol
+++ b/contracts/lib/P2pAddressLib.sol
@@ -16,4 +16,16 @@ library P2pAddressLib {
 
         return success;
     }
+
+    /// @notice Sends amount of ETH in wei to recipient
+    /// @param _recipient address of recipient
+    /// @param _amount amount of ETH in wei
+    /// @return bool whether send succeeded
+    function _sendValueWithoutGasRestrictions(address payable _recipient, uint256 _amount) internal returns (bool) {
+        (bool success, ) = _recipient.call{
+            value: _amount
+        }("");
+
+        return success;
+    }
 }

--- a/contracts/mocks/MockAlteringReceive.sol
+++ b/contracts/mocks/MockAlteringReceive.sol
@@ -12,13 +12,15 @@ contract MockAlteringReceive {
 
     receive() external payable {
         if (s_shouldRevertOnReceive) {
-            for(;;) {
-                // infinite loop to consume all the gas
-            }
+            revert("Intentional revert");
         }
     }
 
     function startRevertingOnReceive() external {
         s_shouldRevertOnReceive = true;
+    }
+
+    function stopRevertingOnReceive() external {
+        s_shouldRevertOnReceive = false;
     }
 }

--- a/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
+++ b/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
@@ -152,23 +152,6 @@ contract P2pOrgUnlimitedEthDepositor is ERC165, IP2pOrgUnlimitedEthDepositor {
         emit P2pOrgUnlimitedEthDepositor__Refund(_feeDistributorInstance, client, amount);
     }
 
-    /// @notice Can be very gas expensive.
-    /// Better use `refundAll(address[])`
-    /// Only callable by client
-    function refundAll() external {
-        address[] memory allClientFeeDistributors = i_feeDistributorFactory.allClientFeeDistributors(msg.sender);
-
-        for (uint256 i = 0; i < allClientFeeDistributors.length;) {
-            refund(allClientFeeDistributors[i]);
-
-            // An array can't have a total length
-            // larger than the max uint256 value.
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
     /// @notice Cheaper, requires calling feeDistributorFactory's allClientFeeDistributors externally first
     /// Only callable by client
     /// @param _allClientFeeDistributors array of all client FeeDistributor instances whose associated ETH amounts should be refunded

--- a/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
+++ b/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
@@ -32,16 +32,15 @@ contract P2pOrgUnlimitedEthDepositor is ERC165, IP2pOrgUnlimitedEthDepositor {
     mapping(address => ClientDeposit) private s_deposits;
 
     /// @dev Set values known at the initial deploy time.
-    /// @param _mainnet Mainnet=true Goerli=false
     /// @param _feeDistributorFactory address of FeeDistributorFactory
-    constructor(bool _mainnet, address _feeDistributorFactory) {
+    constructor(address _feeDistributorFactory) {
         if (!ERC165Checker.supportsInterface(_feeDistributorFactory, type(IFeeDistributorFactory).interfaceId)) {
             revert P2pOrgUnlimitedEthDepositor__NotFactory(_feeDistributorFactory);
         }
 
         i_feeDistributorFactory = IFeeDistributorFactory(_feeDistributorFactory);
 
-        i_depositContract = _mainnet
+        i_depositContract = block.chainid == 1
             ? IDepositContract(0x00000000219ab540356cBB839Cbe05303d7705Fa) // real Mainnet DepositContract
             : IDepositContract(0xff50ed3d0ec03aC01D4C79aAd74928BFF48a7b2b); // real Goerli DepositContract
     }

--- a/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
+++ b/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
@@ -109,6 +109,10 @@ contract P2pOrgUnlimitedEthDepositor is ERC165, IP2pOrgUnlimitedEthDepositor {
     ) external {
         i_feeDistributorFactory.checkOperatorOrOwner(msg.sender);
 
+        if (s_deposits[_feeDistributorInstance].status == ClientDepositStatus.None) {
+            revert P2pOrgUnlimitedEthDepositor__NoDepositToReject(_feeDistributorInstance);
+        }
+
         s_deposits[_feeDistributorInstance].status = ClientDepositStatus.ServiceRejected;
         s_deposits[_feeDistributorInstance].expiration = 0; // allow the client to get a refund immediately
 

--- a/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
+++ b/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
@@ -57,8 +57,8 @@ contract P2pOrgUnlimitedEthDepositor is ERC165, IP2pOrgUnlimitedEthDepositor {
         FeeRecipient calldata _clientConfig,
         FeeRecipient calldata _referrerConfig
     ) external payable returns(address feeDistributorInstance) {
-        if (msg.value == 0) {
-            revert P2pOrgUnlimitedEthDepositor__NoZeroDeposits();
+        if (msg.value < MIN_DEPOSIT) {
+            revert P2pOrgUnlimitedEthDepositor__NoSmallDeposits();
         }
 
         if (!ERC165Checker.supportsInterface(_referenceFeeDistributor, type(IFeeDistributor).interfaceId)) {

--- a/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
+++ b/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositor.sol
@@ -71,6 +71,10 @@ contract P2pOrgUnlimitedEthDepositor is ERC165, IP2pOrgUnlimitedEthDepositor {
             _referrerConfig
         );
 
+        if (s_deposits[feeDistributorInstance].status == ClientDepositStatus.ServiceRejected) {
+            revert P2pOrgUnlimitedEthDepositor__ShouldNotBeRejected(feeDistributorInstance);
+        }
+
         if (feeDistributorInstance.code.length == 0) {
             // if feeDistributorInstance doesn't exist, deploy it
 
@@ -188,6 +192,10 @@ contract P2pOrgUnlimitedEthDepositor is ERC165, IP2pOrgUnlimitedEthDepositor {
         bytes32[] calldata _depositDataRoots
     ) external {
         i_feeDistributorFactory.checkOperatorOrOwner(msg.sender);
+
+        if (s_deposits[_feeDistributorInstance].status == ClientDepositStatus.ServiceRejected) {
+            revert P2pOrgUnlimitedEthDepositor__ShouldNotBeRejected(_feeDistributorInstance);
+        }
 
         uint256 validatorCount = _pubkeys.length;
         uint112 amountToStake = uint112(COLLATERAL * validatorCount);

--- a/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositorErrors.sol
+++ b/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositorErrors.sol
@@ -48,3 +48,7 @@ error P2pOrgUnlimitedEthDepositor__NotFeeDistributor(address _passedAddress);
 /// @notice Should be a FeeDistributorFactory contract
 /// @param _passedAddress passed address that does not support IFeeDistributorFactory interface
 error P2pOrgUnlimitedEthDepositor__NotFactory(address _passedAddress);
+
+/// @notice There is no active deposit for the given FeeDistributor instance
+/// @param _feeDistributorInstance FeeDistributor instance address
+error P2pOrgUnlimitedEthDepositor__NoDepositToReject(address _feeDistributorInstance);

--- a/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositorErrors.sol
+++ b/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositorErrors.sol
@@ -52,3 +52,7 @@ error P2pOrgUnlimitedEthDepositor__NotFactory(address _passedAddress);
 /// @notice There is no active deposit for the given FeeDistributor instance
 /// @param _feeDistributorInstance FeeDistributor instance address
 error P2pOrgUnlimitedEthDepositor__NoDepositToReject(address _feeDistributorInstance);
+
+/// @notice Cannot proceed because a deposit for this FeeDistributor instance has already been rejected
+/// @param _feeDistributorInstance FeeDistributor instance address
+error P2pOrgUnlimitedEthDepositor__ShouldNotBeRejected(address _feeDistributorInstance);

--- a/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositorErrors.sol
+++ b/contracts/p2pEth2Depositor/P2pOrgUnlimitedEthDepositorErrors.sol
@@ -8,8 +8,8 @@ pragma solidity 0.8.10;
 /// @param _amount amount of ETH is wei
 error P2pOrgUnlimitedEthDepositor__FailedToSendEth(address _receiver, uint256 _amount);
 
-/// @notice Deposits must be greater than zero.
-error P2pOrgUnlimitedEthDepositor__NoZeroDeposits();
+/// @notice Deposits must be at least 1 ETH.
+error P2pOrgUnlimitedEthDepositor__NoSmallDeposits();
 
 /// @notice Only client can call refund
 /// @param _caller address calling refund

--- a/contracts/structs/P2pStructs.sol
+++ b/contracts/structs/P2pStructs.sol
@@ -17,12 +17,12 @@ struct FeeRecipient {
 /// @member depositedCount the number of deposited validators
 /// @member exitedCount the number of validators requested to exit
 /// @member collateralReturnedValue amount of ETH returned to the client to cover the collaterals
-/// @member reservedForFutureUse unused space making up to 256 bit.
+/// @member cooldownUntil timestamp after which it will be possible to withdraw ignoring the client's revert on ETH receive
 struct ValidatorData {
     uint32 depositedCount;
     uint32 exitedCount;
     uint112 collateralReturnedValue;
-    uint80 reservedForFutureUse;
+    uint80 cooldownUntil;
 }
 
 /// @dev status of the client deposit

--- a/contracts/structs/P2pStructs.sol
+++ b/contracts/structs/P2pStructs.sol
@@ -16,13 +16,13 @@ struct FeeRecipient {
 /// @dev 256 bit struct
 /// @member depositedCount the number of deposited validators
 /// @member exitedCount the number of validators requested to exit
-/// @member collateralReturnedCount the number of collaterals (multiples of 32 ETH) returned to the client
-/// @member reservedForFutureUse unused space making up to 256 bit. Can be some address in the future.
+/// @member collateralReturnedValue amount of ETH returned to the client to cover the collaterals
+/// @member reservedForFutureUse unused space making up to 256 bit.
 struct ValidatorData {
     uint32 depositedCount;
     uint32 exitedCount;
-    uint32 collateralReturnedCount;
-    uint160 reservedForFutureUse;
+    uint112 collateralReturnedValue;
+    uint80 reservedForFutureUse;
 }
 
 /// @dev status of the client deposit

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -20,7 +20,7 @@ const config: HardhatUserConfig = {
   defaultNetwork: "hardhat",
   networks: {
     hardhat: {
-      chainId: 31337,
+      chainId: 1,
       blockGasLimit: 30000000,
       gasPrice: 0,
       initialBaseFeePerGas: 0,

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -31,7 +31,7 @@ contract Deploy is Script {
         ContractWcFeeDistributor contractWcFeeDistributorTemplate = new ContractWcFeeDistributor(address(factory), serviceAddress);
         ElOnlyFeeDistributor elOnlyFeeDistributorTemplate = new ElOnlyFeeDistributor(address(factory), serviceAddress);
         OracleFeeDistributor oracleFeeDistributorTemplate = new OracleFeeDistributor(address(oracle), address(factory), serviceAddress);
-        P2pOrgUnlimitedEthDepositor p2pEthDepositor = new P2pOrgUnlimitedEthDepositor(block.chainid == 1, address(factory));
+        P2pOrgUnlimitedEthDepositor p2pEthDepositor = new P2pOrgUnlimitedEthDepositor(address(factory));
         factory.setP2pEth2Depositor(address(p2pEthDepositor));
 
         vm.stopBroadcast();

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -65,7 +65,6 @@ async function main() {
 
         // deploy P2pEth2Depositor contract
         const p2pEth2DepositorSignedByDeployer = await new P2pOrgUnlimitedEthDepositor__factory(deployerSigner).deploy(
-            chainId === 1,
             feeDistributorFactorySignedByDeployer.address,
             {gasLimit: 10000000, maxPriorityFeePerGas: 1000, maxFeePerGas: 400000000000}
         )

--- a/test/foundry/Integration.t.sol
+++ b/test/foundry/Integration.t.sol
@@ -112,7 +112,7 @@ contract Integration is Test {
         contractWcFeeDistributorTemplate = new ContractWcFeeDistributor(address(factory), serviceAddress);
         elOnlyFeeDistributorTemplate = new ElOnlyFeeDistributor(address(factory), serviceAddress);
         oracleFeeDistributorTemplate = new OracleFeeDistributor(address(oracle), address(factory), serviceAddress);
-        p2pEthDepositor = new P2pOrgUnlimitedEthDepositor(true, address(factory));
+        p2pEthDepositor = new P2pOrgUnlimitedEthDepositor(address(factory));
         vm.stopPrank();
 
         checkOwnership();

--- a/test/foundry/Integration.t.sol
+++ b/test/foundry/Integration.t.sol
@@ -330,7 +330,24 @@ contract Integration is Test {
     function test_OracleFeeDistributor_Creation_Without_Depositor() public {
         console.log("testOracleFeeDistributorCreationWithoutDepositor started");
 
-        address newFeeDistributorAddress = deployOracleFeeDistributorCreationWithoutDepositor();
+        address newFeeDistributorAddress;
+
+        vm.startPrank(operatorAddress);
+        vm.expectRevert(OracleFeeDistributor__ClientBasisPointsShouldBeHigherThan5000.selector);
+        newFeeDistributorAddress = factory.createFeeDistributor(
+            address(oracleFeeDistributorTemplate),
+            FeeRecipient({
+                recipient: clientWcAddress,
+                basisPoints: 4000
+            }),
+            FeeRecipient({
+                recipient: payable(address(0)),
+                basisPoints: 0
+            })
+        );
+        vm.stopPrank();
+
+        newFeeDistributorAddress = deployOracleFeeDistributorCreationWithoutDepositor();
 
         assertEq(newFeeDistributorAddress, oracleFeeDistributorInstanceAddress);
 
@@ -399,13 +416,13 @@ contract Integration is Test {
         newFeeDistributorAddress = factory.createFeeDistributor(
             address(oracleFeeDistributorTemplate),
             FeeRecipient({
-        recipient: clientWcAddress,
-        basisPoints: defaultClientBasisPoints
-        }),
+                recipient: clientWcAddress,
+                basisPoints: defaultClientBasisPoints
+            }),
             FeeRecipient({
-        recipient: payable(address(0)),
-        basisPoints: 0
-        })
+                recipient: payable(address(0)),
+                basisPoints: 0
+            })
         );
 
         vm.stopPrank();

--- a/test/hh/01-fee-distributor-test.ts
+++ b/test/hh/01-fee-distributor-test.ts
@@ -276,7 +276,7 @@ describe("FeeDistributor", function () {
                 `OwnableBase__CallerNotOwner`
             )
 
-        await expect(feeDistributorSignedByOwner.transferERC721(erc721.address, serviceAddress, erc721TokenId, "0x", {gasLimit: 30000000}))
+        await expect(feeDistributorSignedByOwner.transferERC721(erc721.address, serviceAddress, erc721TokenId, {gasLimit: 30000000}))
             .to.be.revertedWith(
                 `OwnableBase__CallerNotOwner`
             )
@@ -289,7 +289,7 @@ describe("FeeDistributor", function () {
         const recipientErc20Balance = await erc20.balanceOf(serviceAddress)
         expect(recipientErc20Balance).to.be.equal(erc20Amount)
 
-        await feeDistributorSignedByOwner.transferERC721(erc721.address, serviceAddress, erc721TokenId, "0x", {gasLimit: 30000000})
+        await feeDistributorSignedByOwner.transferERC721(erc721.address, serviceAddress, erc721TokenId, {gasLimit: 30000000})
         const recipientErc721Balance = await erc721.balanceOf(serviceAddress)
         expect(recipientErc721Balance).to.be.equal(1)
     })

--- a/test/hh/02-factory-test.ts
+++ b/test/hh/02-factory-test.ts
@@ -238,7 +238,7 @@ describe("FeeDistributorFactory", function () {
                 `OwnableBase__CallerNotOwner`
             )
 
-        await expect(factorySignedByOwner.transferERC721(erc721.address, nobody, erc721TokenId, "0x", {gasLimit: 30000000}))
+        await expect(factorySignedByOwner.transferERC721(erc721.address, nobody, erc721TokenId, {gasLimit: 30000000}))
             .to.be.revertedWith(
                 `OwnableBase__CallerNotOwner`
             )
@@ -255,7 +255,7 @@ describe("FeeDistributorFactory", function () {
         const recipientErc20Balance = await erc20.balanceOf(nobody)
         expect(recipientErc20Balance).to.be.equal(erc20Amount)
 
-        await factorySignedByOwner.transferERC721(erc721.address, nobody, erc721TokenId, "0x", {gasLimit: 30000000})
+        await factorySignedByOwner.transferERC721(erc721.address, nobody, erc721TokenId, {gasLimit: 30000000})
         const recipientErc721Balance = await erc721.balanceOf(nobody)
         expect(recipientErc721Balance).to.be.equal(1)
 

--- a/test/hh/04-test-emergency-ether-recovery-without-oracle-data.ts
+++ b/test/hh/04-test-emergency-ether-recovery-without-oracle-data.ts
@@ -76,7 +76,6 @@ describe("test emergencyEtherRecoveryWithoutOracleData", function () {
 
         // deploy P2pOrgUnlimitedEthDepositor contract
         P2pOrgUnlimitedEthDepositorSignedByDeployer = await new P2pOrgUnlimitedEthDepositor__factory(deployerSigner).deploy(
-            true,
             feeDistributorFactorySignedByDeployer.address
         )
 


### PR DESCRIPTION
Fix
1. Rewards can be accounted as collateral
2. The slashed validator’s stake gets split between client, referrer, and service